### PR TITLE
ci(semantic-release): added config to publish new versions

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,0 +1,17 @@
+{
+  "prepare": [
+    "@semantic-release/changelog",
+    "@semantic-release/npm",
+    {
+      "path": "@semantic-release/git",
+      "assets": ["CHANGELOG.md"]
+    }
+  ],
+  "publish": [
+    "@semantic-release/npm",
+    {
+      "path": "@semantic-release/github",
+      "assets": [{"path": "browser/dist/*.js"}]
+    }
+  ]
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,10 +16,16 @@ sudo: false
 # versions 4-7 because the build for the first GK commit (that updates
 # package.json) will fail on those versions in the greenkeeper-lockfile-update
 # step.
-before_install: '[[ $(node -v) =~ ^v4.*$ ]] || [[ $(node -v) =~ ^v5.*$ ]] || [[ $(node -v) =~ ^v6.*$ ]] || [[ $(node -v) =~ ^v7.*$ ]] || npm install -g greenkeeper-lockfile'
+before_install:
+- '[[ $(node -v) =~ ^v4.*$ ]] || [[ $(node -v) =~ ^v5.*$ ]] || [[ $(node -v) =~ ^v6.*$ ]] || [[ $(node -v) =~ ^v7.*$ ]] || npm install -g greenkeeper-lockfile'
+- npm install --global @semantic-release/changelog @semantic-release/git
 install: npm install
 before_script: '[[ $(node -v) =~ ^v4.*$ ]] || [[ $(node -v) =~ ^v5.*$ ]] || [[ $(node -v) =~ ^v6.*$ ]] || [[ $(node -v) =~ ^v7.*$ ]] || greenkeeper-lockfile-update'
 after_script: '[[ $(node -v) =~ ^v4.*$ ]] || [[ $(node -v) =~ ^v5.*$ ]] || [[ $(node -v) =~ ^v6.*$ ]] || [[ $(node -v) =~ ^v7.*$ ]] || greenkeeper-lockfile-upload'
+deploy:
+  provider: script
+  skip_cleanup: true
+  script: npx semantic-release
 
 env:
   global:


### PR DESCRIPTION
i think this should configure semantic release to still publish to npm and cut a github release, as it does by default, but also take care of updating and commiting/pushing changelog updates and attaching the `js` files from `browser/dist/` to the github release.

were there any additional steps that you wanted that don't appear to be covered with this config?

my goal is to confirm this config works the way we want and then extract a shareable config to an npm package that gets extended from in this and all the other projects. 

i think this config should be close, but might take a few tries to ensure there aren't kinks to work out. is this a good project to try things out with, or do you have another one that you'd recommend moving this to initially.